### PR TITLE
Fix bug where editing history will only ever change the top session (hopefully)

### DIFF
--- a/SIS App/Views/HistoryRow.swift
+++ b/SIS App/Views/HistoryRow.swift
@@ -12,6 +12,8 @@ struct HistoryRow: View {
     var showTiming = true
     var showTarget = true
 
+    @Binding var currentlySelectedSession: CheckInSession?
+
     var editable = false
     var onTargetPressed: (() -> Void)?
     var onCheckInDateUpdate: ((Date) -> Void)?
@@ -26,8 +28,8 @@ struct HistoryRow: View {
         self.showTarget = showTarget
 
         _checkInDate = .init(initialValue: self.session.checkedIn)
-        _checkOutDate = .init(initialValue: self.session.checkedOut!)
-        // Force unwrapping because if this is to appear in history, they must have already checked out
+        _checkOutDate = .init(initialValue: self.session.checkedOut!) // Force unwrapping because if this is to appear in history, they must have already checked out
+        _currentlySelectedSession = .constant(nil)
 
         editable = false
         onTargetPressed = nil
@@ -38,6 +40,7 @@ struct HistoryRow: View {
     init(
         session: CheckInSession, showTiming: Bool = true, showTarget: Bool = true,
         editable: Bool,
+        currentlySelectedSession: Binding<CheckInSession?>? = nil,
         onTargetPressed: @escaping (() -> Void),
         onCheckInDateUpdate: @escaping ((Date) -> Void),
         onCheckOutDateUpdate: @escaping ((Date) -> Void)
@@ -46,6 +49,7 @@ struct HistoryRow: View {
 
         if editable {
             self.editable = true
+            _currentlySelectedSession = currentlySelectedSession ?? .constant(nil)
             self.onTargetPressed = onTargetPressed
             self.onCheckInDateUpdate = onCheckInDateUpdate
             self.onCheckOutDateUpdate = onCheckOutDateUpdate
@@ -69,6 +73,7 @@ struct HistoryRow: View {
                         )
                         .labelsHidden()
                         .onChange(of: checkInDate) { newValue in
+                            currentlySelectedSession = session
                             onCheckInDateUpdate?(newValue)
                         }
                         DatePicker(
@@ -79,6 +84,7 @@ struct HistoryRow: View {
                         )
                         .labelsHidden()
                         .onChange(of: checkOutDate) { newValue in
+                            currentlySelectedSession = session
                             onCheckOutDateUpdate?(newValue)
                         }
                     }
@@ -107,6 +113,7 @@ struct HistoryRow: View {
                     }
                 }
                 .onTapGesture {
+                    currentlySelectedSession = session
                     onTargetPressed?()
                 }
                 .conditionalModifier(editable) {

--- a/SIS App/Views/HistoryView.swift
+++ b/SIS App/Views/HistoryView.swift
@@ -11,6 +11,7 @@ struct HistoryView: View {
     @EnvironmentObject var checkInManager: CheckInManager
 
     @State private var showingEditRoomScreen = false
+    @State private var currentlySelectedSession: CheckInSession? = nil
 
     var body: some View {
         NavigationView {
@@ -21,21 +22,26 @@ struct HistoryView: View {
                             HistoryRow(
                                 session: session,
                                 editable: true,
+                                currentlySelectedSession: $currentlySelectedSession,
                                 onTargetPressed: {
                                     showingEditRoomScreen = true
                                 },
                                 onCheckInDateUpdate: { newCheckInDate in
-                                    print("new check in date: \(newCheckInDate)")
+                                    guard let currentlySelectedSession = currentlySelectedSession else { return }
+
+                                    print("🗂 new check in date: \(newCheckInDate)")
                                     checkInManager.updateCheckInSession(
-                                        id: session.id,
-                                        newSession: session.newSessionWith(checkedIn: newCheckInDate)
+                                        id: currentlySelectedSession.id,
+                                        newSession: currentlySelectedSession.newSessionWith(checkedIn: newCheckInDate)
                                     )
                                 },
                                 onCheckOutDateUpdate: { newCheckOutDate in
-                                    print("new check out date: \(newCheckOutDate)")
+                                    guard let currentlySelectedSession = currentlySelectedSession else { return }
+
+                                    print("🗂 new check out date: \(newCheckOutDate)")
                                     checkInManager.updateCheckInSession(
-                                        id: session.id,
-                                        newSession: session.newSessionWith(checkedOut: newCheckOutDate)
+                                        id: currentlySelectedSession.id,
+                                        newSession: currentlySelectedSession.newSessionWith(checkedOut: newCheckOutDate)
                                     )
                                 }
                             )
@@ -43,9 +49,11 @@ struct HistoryView: View {
                                 ChooseRoomView(onRoomSelection: { room in
                                     showingEditRoomScreen = false
 
+                                    guard let currentlySelectedSession = currentlySelectedSession else { return }
+                                    print("🗂 saving session: \(session)")
                                     checkInManager.updateCheckInSession(
-                                        id: session.id,
-                                        newSession: session.newSessionWith(target: room)
+                                        id: currentlySelectedSession.id,
+                                        newSession: currentlySelectedSession.newSessionWith(target: room)
                                     )
                                 }, onBackButtonPressed: {
                                     showingEditRoomScreen = false


### PR DESCRIPTION
@hz7217 Test to see if editing the history actually gives the correct result (aka if i change the 2nd session, the 2nd session should change). Previously no matter which session you edited it would always change the first session, now it should be correct.
