### PR TITLE
Only display one item even if room takes up multiple unit numbers

### DIFF
--- a/SIS App.xcodeproj/project.pbxproj
+++ b/SIS App.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		62868F332560009600F81842 /* UserNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62868F322560009600F81842 /* UserNotificationHelper.swift */; };
 		62881EAE2556570A00787923 /* categories.json in Resources */ = {isa = PBXBuildFile; fileRef = 62881EAD2556570A00787923 /* categories.json */; };
 		62881EB1255657EE00787923 /* CategoryDisplayNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62881EB0255657EE00787923 /* CategoryDisplayNames.swift */; };
+		628BF886257F641E00CFA807 /* Array+UniqueRooms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628BF885257F641E00CFA807 /* Array+UniqueRooms.swift */; };
 		628D11D725598F8D00BF4D2E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628D11D625598F8D00BF4D2E /* SearchView.swift */; };
 		628D11DB2559970300BF4D2E /* SwiftUIX in Frameworks */ = {isa = PBXBuildFile; productRef = 628D11DA2559970300BF4D2E /* SwiftUIX */; };
 		628D11DE255997DB00BF4D2E /* colors.json in Resources */ = {isa = PBXBuildFile; fileRef = 628D11DD255997DB00BF4D2E /* colors.json */; };
@@ -153,6 +154,7 @@
 		62881EAD2556570A00787923 /* categories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = categories.json; sourceTree = "<group>"; };
 		62881EB0255657EE00787923 /* CategoryDisplayNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDisplayNames.swift; sourceTree = "<group>"; };
 		62881EB325565C2200787923 /* RoomsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomsView.swift; sourceTree = "<group>"; };
+		628BF885257F641E00CFA807 /* Array+UniqueRooms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+UniqueRooms.swift"; sourceTree = "<group>"; };
 		628D11D625598F8D00BF4D2E /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchView.swift; path = "SIS App/Views/SearchView.swift"; sourceTree = SOURCE_ROOT; };
 		628D11DD255997DB00BF4D2E /* colors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = colors.json; path = "SIS App/Data/colors.json"; sourceTree = SOURCE_ROOT; };
 		628D11E0255997FC00BF4D2E /* LevelColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LevelColors.swift; path = "SIS App/Utilities/LevelColors.swift"; sourceTree = SOURCE_ROOT; };
@@ -253,6 +255,7 @@
 		62756C2A25598BEE0007C4F3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				628BF885257F641E00CFA807 /* Array+UniqueRooms.swift */,
 				628FAAC72573D7A40010F040 /* IntersectionChecker.swift */,
 				6255C34C256E49450052B38C /* FileUtility.swift */,
 				629EB67F25638E64000FADD9 /* View+ConditionalModifiers.swift */,
@@ -275,8 +278,8 @@
 				62E119EC253ADEBF0037CEC5 /* HomeView.swift */,
 				62D5D63F255D3E850064D484 /* ChooseRoomView.swift */,
 				6292DCBD25564F4000352527 /* CategoriesView.swift */,
-				62A53B4A256E41A30092E891 /* IconView.swift */,
 				62881EB325565C2200787923 /* RoomsView.swift */,
+				62A53B4A256E41A30092E891 /* IconView.swift */,
 				6202DDC52558102F0017BC49 /* CheckedInView.swift */,
 				62FC0BB3256D48F900EACA79 /* GradientButtonStyle.swift */,
 				6202DDCF255827DF0017BC49 /* HistoryView.swift */,
@@ -527,6 +530,7 @@
 				621A877D2551832C00FA810F /* Block.swift in Sources */,
 				628D11E1255997FC00BF4D2E /* LevelColors.swift in Sources */,
 				6202DDD325583CC90017BC49 /* RoomParentInfo.swift in Sources */,
+				628BF886257F641E00CFA807 /* Array+UniqueRooms.swift in Sources */,
 				621A77EA25566CCE00636B27 /* Location.swift in Sources */,
 				6258F06B256771E30021438C /* SISAppWidget.intentdefinition in Sources */,
 				628D11E8255AB44D00BF4D2E /* LevelIcon.swift in Sources */,

--- a/SIS App/Models/CheckInManager.swift
+++ b/SIS App/Models/CheckInManager.swift
@@ -86,7 +86,7 @@ class CheckInManager: ObservableObject {
         // ------- [[ SET STATE ]] -------- //
         isCheckedIn = false
         if shouldUpdateUI { showCheckedInScreen = false }
-        currentSession?.checkedOut = Date()
+        currentSession!.checkedOut = Date()
 
         // -------- [[ ADD TO SAVED SESSIONS ]] ------- //
         checkInSessions.append(currentSession!)

--- a/SIS App/Utilities/Array+UniqueRooms.swift
+++ b/SIS App/Utilities/Array+UniqueRooms.swift
@@ -1,0 +1,25 @@
+//
+//  Array+UniqueRooms.swift
+//  SIS App
+//
+//  Created by Wang Yunze on 8/12/20.
+//
+
+import Foundation
+
+extension Array where Element == Room {
+    /// This is to deal with rooms like RDS which take up more than one unit number
+    /// This considers the rooms to be the same so long as their names are the same
+    /// NOT the IDs.
+    func uniqueRooms() -> [Room] {
+        var temp = [Room]()
+        var added: Set<String> = []
+        for element in self {
+            if !added.contains(element.name) {
+                added.insert(element.name)
+                temp.append(element)
+            }
+        }
+        return temp
+    }
+}

--- a/SIS App/Views/ChooseRoomView.swift
+++ b/SIS App/Views/ChooseRoomView.swift
@@ -23,8 +23,6 @@ struct ChooseRoomView: View {
         self.onRoomSelection = onRoomSelection
     }
 
-    let blocks = DataProvider.getBlocks()
-
     var body: some View {
         HStack {
             if onBackButtonPressed != nil {
@@ -49,17 +47,7 @@ struct ChooseRoomView: View {
                 .buttonStyle(PlainButtonStyle())
         }
         NavigationView {
-            List(blocks.sorted(by: { (block1, block2) -> Bool in
-                // If location avaliable, sort by distance to nearest block
-                if let dist1 = userLocationManager.userLocation?.distance(from: block1.location.toCLLocation()),
-                   let dist2 = userLocationManager.userLocation?.distance(from: block2.location.toCLLocation())
-                {
-                    return dist1 - block1.radius < dist2 - block2.radius
-                }
-
-                // Else sort by name
-                return block1.name < block2.name
-            }), id: \.name) { block in
+            List(DataProvider.getBlocks(userLocation: userLocationManager.userLocation), id: \.name) { block in
                 NavigationLink(
                     destination: CategoriesView(
                         categories: block.categories,

--- a/SIS App/Views/RoomsView.swift
+++ b/SIS App/Views/RoomsView.swift
@@ -18,9 +18,7 @@ struct RoomsView: View {
         List {
             ForEach(roomSections()) { level in
                 Section(header: Text("Level \(level.level)")) {
-                    ForEach(level.rooms.sorted(by: { room1, room2 in
-                        room1.name < room2.name
-                    })) { room in
+                    ForEach(level.rooms.sorted { $0.name < $1.name }) { room in
                         Button(
                             action: {
                                 onRoomSelection(room)
@@ -42,23 +40,22 @@ struct RoomsView: View {
 
     private func roomSections() -> [Level] {
         var levels = [Int: Level]()
+        let uniqueRooms = rooms.uniqueRooms()
 
         var uniqueLevelNums: Set<Int> = []
-        for room in rooms {
+        for room in uniqueRooms {
             uniqueLevelNums.insert(room.level)
         }
 
-        for i in uniqueLevelNums {
-            levels[i] = Level(rooms: [], level: i)
+        for level in uniqueLevelNums {
+            levels[level] = Level(rooms: [], level: level)
         }
 
-        for room in rooms {
+        for room in uniqueRooms {
             levels[room.level]?.rooms.append(room)
         }
 
-        let toReturn = Array(levels.values).sorted { level1, level2 in
-            level1.level < level2.level
-        }
+        let toReturn = Array(levels.values).sorted { $0.level < $1.level }
 
         return toReturn
     }


### PR DESCRIPTION
I might change how this is implemented later, currently it just hids all but one of them. The problem is i can't figure out how to _check in_ to more than one _id_ without it appearing as more than one in history.